### PR TITLE
fix: preserve file structure to avoid trailing slashes

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,6 +11,9 @@ export default defineConfig({
   image: {
     service: sharpImageService({ limitInputPixels: false }),
   },
+  build: {
+    format: "preserve",
+  },
   trailingSlash: "never",
   integrations: [
     starlight({


### PR DESCRIPTION
GitHub Pages need a different structure of the HTML files. To avoid having trailing slashes on the URL's end, files should be like `/getting-structure/configuration.html` and not `/getting-structure/configuration/index.html`

- https://stackoverflow.com/questions/33270605/github-pages-trailing-slashes
- https://docs.astro.build/en/reference/configuration-reference/#buildformat