### PR TITLE
fix: ignore trailing slash at the end

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -14,7 +14,7 @@ export default defineConfig({
   build: {
     format: "preserve",
   },
-  trailingSlash: "never",
+  trailingSlash: "ignore",
   integrations: [
     starlight({
       logo: {


### PR DESCRIPTION
https://docs.astro.build/en/reference/configuration-reference/#trailingslash